### PR TITLE
Fix ingressClassName to get IP assigned

### DIFF
--- a/helm/values/pihole.values.yaml
+++ b/helm/values/pihole.values.yaml
@@ -4,6 +4,7 @@ DNS1:
 persistentVolumeClaim:
   enabled: true
 ingress:
+  ingressClassName: nginx-internal
   enabled: true
   hosts:
     - "pihole.home"


### PR DESCRIPTION
An IP address is not assigned in the SVC because the className is missing. Adding it resolves the issue, an IP is given and pihole will then get correct DNS record.