### PR TITLE
fix: external-dns does not work when adding ip for my pihole

### DIFF
--- a/helm/values/pihole.values.yaml
+++ b/helm/values/pihole.values.yaml
@@ -7,6 +7,8 @@ ingress:
   enabled: true
   hosts:
     - "pihole.home"
+  annotations:
+    kubernetes.io/ingress.class: "nginx-internal"
 serviceWeb:
   loadBalancerIP: 192.168.1.250
   annotations:


### PR DESCRIPTION
Just as the title says, this PR solves this issue.

Just add a nginx annotation rule.

Closes #3 